### PR TITLE
[Source Map] fix source map for build & demo

### DIFF
--- a/demo/default/webpack.config.js
+++ b/demo/default/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path');
 
 module.exports = {
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   entry: {
     default: './index.js',
   },

--- a/demo/default/webpack.config.js
+++ b/demo/default/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path');
 
 module.exports = {
-  devtool: 'source-map',
+  devtool: 'inline-source-map',
   entry: {
     default: './index.js',
   },
@@ -13,12 +13,25 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
+      {
         test: /\.vue$/,
         loader: 'vue-loader',
+        options: {
+          loaders: {
+            js: 'babel-loader',
+          },
+          preLoaders: {
+            js: 'eslint-loader',
+          },
+        }
       },
       {
         enforce: 'pre',
-        test: /\.(js|vue)$/,
+        test: /\.js$/,
         loader: 'eslint-loader',
         exclude: [/node_modules/, /dist/],
       },
@@ -54,8 +67,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'vue-projection-grid': path.join(__dirname, '../../src/index'),
-      'projection-grid-core': 'projection-grid-core/src/index',
+      'vue-projection-grid': require.resolve('../../dist/index'),
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "less-loader": "^4.0.5",
     "raf": "^3.4.0",
     "sinon": "^4.1.2",
+    "source-map-loader": "^0.2.3",
     "style-loader": "^0.19.0",
     "url-loader": "^0.6.2",
     "vue-jest": "^1.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,22 +14,32 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
+      {
         test: /\.vue$/,
         loader: 'vue-loader',
         options: {
-          loaders: 'vue-test-loader',
+          loaders: {
+            js: 'babel-loader',
+          },
+          preLoaders: {
+            js: 'eslint-loader',
+          },
         },
       },
       {
         enforce: 'pre',
-        test: /\.(js|vue)$/,
+        test: /\.js$/,
         loader: 'eslint-loader',
-        exclude: /node_modules/,
+        exclude: [/node_modules/, /dist/],
       },
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        exclude: /node_modules/,
+        exclude: [/node_modules/, /dist/],
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,7 +250,7 @@ async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4, async@^2.4.1:
+async@^2.1.2, async@^2.1.4, async@^2.4.1, async@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -3772,6 +3772,15 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
+loader-utils@~0.2.2:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+    object-assign "^4.0.1"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -5412,6 +5421,14 @@ sort-keys@^1.0.0:
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
+source-map-loader@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.3.tgz#d4b0c8cd47d54edce3e6bfa0f523f452b5b0e521"
+  dependencies:
+    async "^2.5.0"
+    loader-utils "~0.2.2"
+    source-map "~0.6.1"
 
 source-map-support@^0.4.15:
   version "0.4.18"


### PR DESCRIPTION
1. For build, `webpack.config.js` is fixed by adding `source-map-loader` to load `projection-grid-core` source map.
2. For demo, `demo/default/webpack.config.js` is fixed by adding `source-map-loader`. 
3. Fix how we use `vue-loader` in both configs.
4. Fix scope of babel and eslint loader.

Now we can see
   * demo code source in `webpack://.`
   * `vue-projection-grid` source in `webpack://webpack://src`
   * `projection-grid-code` source in `webpack://webpack://webpack:src`
![image](https://user-images.githubusercontent.com/5836327/33476566-5dec9480-d6bd-11e7-9935-89bf06a8d179.png)

